### PR TITLE
Use 64GB image for ephemeral images on F4s_V2

### DIFF
--- a/ubuntu-agent-vm/ubuntu-agent-vm-aib.json
+++ b/ubuntu-agent-vm/ubuntu-agent-vm-aib.json
@@ -10,7 +10,7 @@
         "buildTimeoutInMinutes": 80,
         "vmProfile": {
             "vmSize": "Standard_D1_v2",
-            "osDiskSizeGB": 128
+            "osDiskSizeGB": 64
         },
         "source": {
             "type": "PlatformImage",


### PR DESCRIPTION
Currently we create 128GB linux images, when switching to ephemeral images these are too big as the cache is 64GB.

This PR resizes the image to be 64GB to allow it to deploy to an ephemeral image. 