### PR TITLE
Install drainer through NSSM

### DIFF
--- a/customscriptextension.ps1
+++ b/customscriptextension.ps1
@@ -64,16 +64,16 @@ Expand-Archive -Path ./$zip -DestinationPath .
 
 Write-Information "###### INSTALL DRAINER ######"
 
+choco install nssm -y
+
 $installPath = "C:\drainer"
-
 New-Item $installPath -ItemType Directory
-
 Set-Location $installPath
-
 $zip = "azurevmagentservice.zip"
-
 wget "https://github.com/UKHO/AzDoAgentDrainer/releases/latest/download/azurevmagentservice.zip" -OutFile ./$zip
-
 Expand-Archive -Path ./$zip -DestinationPath .
 
-#dotnet $installPath\AzureVmAgentsService.dll --drainer:uri=https://dev.azure.com/$account --drainer:pat=$PAT
+$scriptName = "runAzureVMService.bat"
+New-Item -Path . -Name $scriptName -ItemType "file" -Value "dotnet AzureVmAgentsService.dll --drainer:uri=https://dev.azure.com/$account --drainer:pat=$PAT"
+nssm install AzureVmAgentsService "$installPath\$scriptName"
+nssm start AzureVmAgentsService


### PR DESCRIPTION
This PR installs the drainer through NSSM. Installing through powershell cmdlets or using sc.exe proved [unnecessarily fiddly](https://stackoverflow.com/a/11084834/5730574) and lacked configuration options such as setting the working directory for the service. 

Using NSSM reduces these problems as it can just run a script.

There is a risk the choco install might fail but this should be minimal and if it does fail intermittently it is not a huge problem as this is not a on the critical path. Just provides a tidying up service!