### PR TITLE
Updated Customscriptextension, docker service reconfigure

### DIFF
--- a/customscriptextension.ps1
+++ b/customscriptextension.ps1
@@ -73,6 +73,9 @@ Expand-Archive -Path ./$zip -DestinationPath .
 Add-LocalGroupMember -Group Administrators -Member "NT AUTHORITY\NetworkService"
 .\config.cmd --unattended --url https://dev.azure.com/$account --auth PAT --token $PAT --pool "$PoolName" --agent "$agentName" --runAsService
 
+Write-Information "###### Docker Service Config ######"
+SC failure docker reset=0 actions=restart/60000/restart/60000/run/60000 command=""shutdown" "/T00""
+
 Write-Information "###### INSTALL DRAINER ######"
 
 choco install nssm -y

--- a/customscriptextension.ps1
+++ b/customscriptextension.ps1
@@ -76,6 +76,10 @@ Add-LocalGroupMember -Group Administrators -Member "NT AUTHORITY\NetworkService"
 Write-Information "###### Docker Service Config ######"
 SC failure docker reset=0 actions=restart/60000/restart/60000/run/60000 command=""shutdown" "/T00""
 
+Write-Information "###### Docker Service Restart ######"
+$varService = "docker"
+Get-Service -Name $varService | Restart-Service
+
 Write-Information "###### INSTALL DRAINER ######"
 
 choco install nssm -y


### PR DESCRIPTION
The Docker service on the agents has been stopping after creation, an extra command has been added to retry and restart the service. If that fails after two attements it will shutdown the agent. This will cause a new one to be spun up.